### PR TITLE
Configure github workflows (publish not main)

### DIFF
--- a/.github/workflows/package-lock-checks.yml
+++ b/.github/workflows/package-lock-checks.yml
@@ -1,8 +1,6 @@
 name: Check package-lock.json
 
 on:
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-not-main.yml
+++ b/.github/workflows/publish-not-main.yml
@@ -1,0 +1,40 @@
+name: Publish (not main)
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        type: choice
+        description: NPM channel
+        options: 
+        - alpha
+        - beta
+        - previous
+
+permissions:
+  contents: write
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      
+      - run: npm ci
+      - run: npm test
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG=v$(node -p "require('./package.json').version")
+          gh release create --prerelease $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes
+      
+      - name: Publish to npmjs
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: npm publish --access=public --tag=${{ github.event.inputs.channel }}


### PR DESCRIPTION
 - Add new workflow `publish-not-main` for alpha / beta releases.
 - Only check package lock file on demand (so that we don't need to alter it too often).