### PR TITLE
Implement sign message

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+## License
+
+The MIT License (MIT)
+
+Copyright (c) MultiversX
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-web-wallet-provider",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-web-wallet-provider",
-      "version": "2.3.0-beta.0",
+      "version": "2.3.0-beta.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "qs": "6.10.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-web-wallet-provider",
-  "version": "2.2.1",
+  "version": "2.3.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-web-wallet-provider",
-      "version": "2.2.1",
+      "version": "2.3.0-beta.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "qs": "6.10.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-web-wallet-provider",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-web-wallet-provider",
-      "version": "2.3.0-beta.1",
+      "version": "2.3.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "qs": "6.10.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-web-wallet-provider",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.0",
   "description": "Signing provider for dApps: MultiversX (Web) Wallet",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-web-wallet-provider",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0-beta.1",
   "description": "Signing provider for dApps: MultiversX (Web) Wallet",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-web-wallet-provider",
-  "version": "2.2.1",
+  "version": "2.3.0-beta.0",
   "description": "Signing provider for dApps: MultiversX (Web) Wallet",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,11 +1,11 @@
-export class ErrCannotSignTransactions extends Error {
+export class ErrCannotGetSignedTransactions extends Error {
   public constructor() {
-    super("Cannot sign transaction(s)");
+    super("Cannot get signed transaction(s)");
   }
 }
 
-export class ErrCannotSignMessage extends Error {
+export class ErrCannotSignedMessage extends Error {
   public constructor() {
-    super("Cannot sign message");
+    super("Cannot get signed message");
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,20 +1,11 @@
-/**
- * The base class for exceptions (errors).
- */
- export class Err extends Error {
-    inner: Error | undefined = undefined;
-
-    public constructor(message: string, inner?: Error) {
-        super(message);
-        this.inner = inner;
-    }
+export class ErrCannotSignTransactions extends Error {
+  public constructor() {
+    super("Cannot sign transaction(s)");
+  }
 }
 
-/**
- * Signals that the data inside the url is not a valid one for a transaction sign response
- */
- export class ErrInvalidTxSignReturnValue extends Err {
-    public constructor() {
-      super("Invalid response in transaction sign return url");
-    }
+export class ErrCannotSignMessage extends Error {
+  public constructor() {
+    super("Cannot sign message");
   }
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,3 +1,7 @@
 export interface ITransaction {
   toPlainObject(): any;
 }
+
+export interface ISignableMessage {
+  message: Buffer;
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,7 +1,3 @@
 export interface ITransaction {
   toPlainObject(): any;
 }
-
-export interface IMessage {
-  toPlainObject(): any;
-}

--- a/src/walletProvider.ts
+++ b/src/walletProvider.ts
@@ -8,7 +8,7 @@ import {
     WALLET_PROVIDER_SIGN_TRANSACTION_URL
 } from "./constants";
 import { ErrCannotGetSignedTransactions, ErrCannotSignedMessage } from "./errors";
-import { ITransaction } from "./interface";
+import { ISignableMessage, ITransaction } from "./interface";
 import { PlainSignedTransaction } from "./plainSignedTransaction";
 
 export class WalletProvider {
@@ -79,12 +79,12 @@ export class WalletProvider {
      * @param message
      * @param options
      */
-    async signMessage(message: string, options?: { callbackUrl?: string }): Promise<string> {
+    async signMessage(message: ISignableMessage, options?: { callbackUrl?: string }): Promise<string> {
         const redirectUrl = this.buildWalletUrl({
             endpoint: WALLET_PROVIDER_SIGN_MESSAGE_URL,
             callbackUrl: options?.callbackUrl,
             params: {
-                message
+                message: message.message.toString()
             }
         });
 

--- a/src/walletProvider.ts
+++ b/src/walletProvider.ts
@@ -7,7 +7,7 @@ import {
     WALLET_PROVIDER_SIGN_MESSAGE_URL,
     WALLET_PROVIDER_SIGN_TRANSACTION_URL
 } from "./constants";
-import { ErrCannotSignMessage, ErrCannotSignTransactions } from "./errors";
+import { ErrCannotGetSignedTransactions, ErrCannotSignedMessage } from "./errors";
 import { ITransaction } from "./interface";
 import { PlainSignedTransaction } from "./plainSignedTransaction";
 
@@ -98,10 +98,10 @@ export class WalletProvider {
 
         const urlParams = qs.parse(url);
         const status = urlParams.status?.toString() || "";
-        const expectedStatus = "success";
+        const expectedStatus = "signed";
 
         if (status !== expectedStatus) {
-            throw new ErrCannotSignMessage();
+            throw new ErrCannotSignedMessage();
         }
 
         const signature = urlParams.signature?.toString() || "";
@@ -168,14 +168,14 @@ export class WalletProvider {
 
         for (let txProp of expectedProps) {
             if (!urlParams[txProp] || !Array.isArray(urlParams[txProp])) {
-                throw new ErrCannotSignTransactions();
+                throw new ErrCannotGetSignedTransactions();
             }
         }
 
         const expectedLength = urlParams["nonce"].length;
         for (let txProp of expectedProps) {
             if (urlParams[txProp].length !== expectedLength) {
-                throw new ErrCannotSignTransactions();
+                throw new ErrCannotGetSignedTransactions();
             }
         }
 

--- a/src/walletProvider.ts
+++ b/src/walletProvider.ts
@@ -1,14 +1,14 @@
 import qs from "qs";
-import { IMessage, ITransaction } from "./interface";
 import {
     WALLET_PROVIDER_CALLBACK_PARAM,
     WALLET_PROVIDER_CALLBACK_PARAM_TX_SIGNED,
     WALLET_PROVIDER_CONNECT_URL,
     WALLET_PROVIDER_DISCONNECT_URL,
     WALLET_PROVIDER_SIGN_MESSAGE_URL,
-    WALLET_PROVIDER_SIGN_TRANSACTION_URL,
+    WALLET_PROVIDER_SIGN_TRANSACTION_URL
 } from "./constants";
-import { ErrInvalidTxSignReturnValue } from "./errors";
+import { ErrCannotSignMessage, ErrCannotSignTransactions } from "./errors";
+import { ITransaction } from "./interface";
 import { PlainSignedTransaction } from "./plainSignedTransaction";
 
 export class WalletProvider {
@@ -79,7 +79,7 @@ export class WalletProvider {
      * @param message
      * @param options
      */
-    async signMessage(message: IMessage, options?: { callbackUrl?: string }): Promise<string> {
+    async signMessage(message: string, options?: { callbackUrl?: string }): Promise<string> {
         const redirectUrl = this.buildWalletUrl({
             endpoint: WALLET_PROVIDER_SIGN_MESSAGE_URL,
             callbackUrl: options?.callbackUrl,
@@ -90,6 +90,22 @@ export class WalletProvider {
 
         await this.redirect(redirectUrl);
         return redirectUrl;
+    }
+
+    getMessageSignatureFromWalletUrl(): string {
+        const url = window.location.search.slice(1);
+        console.info("getMessageSignatureFromWalletUrl(), url:", url);
+
+        const urlParams = qs.parse(url);
+        const status = urlParams.status?.toString() || "";
+        const expectedStatus = "success";
+
+        if (status !== expectedStatus) {
+            throw new ErrCannotSignMessage();
+        }
+
+        const signature = urlParams.signature?.toString() || "";
+        return signature;
     }
 
     /**
@@ -144,7 +160,7 @@ export class WalletProvider {
     }
 
     private getTxSignReturnValue(urlParams: any): PlainSignedTransaction[] {
-        console.info(`Received urlParams: ${urlParams}`);
+        console.info("getTxSignReturnValue(), urlParams:", urlParams);
 
         // "options", "data" properties are optional (it isn't always received from the Web Wallet)
         const expectedProps = ["nonce", "value", "receiver", "sender", "gasPrice",
@@ -152,14 +168,14 @@ export class WalletProvider {
 
         for (let txProp of expectedProps) {
             if (!urlParams[txProp] || !Array.isArray(urlParams[txProp])) {
-                throw new ErrInvalidTxSignReturnValue();
+                throw new ErrCannotSignTransactions();
             }
         }
 
         const expectedLength = urlParams["nonce"].length;
         for (let txProp of expectedProps) {
             if (urlParams[txProp].length !== expectedLength) {
-                throw new ErrInvalidTxSignReturnValue();
+                throw new ErrCannotSignTransactions();
             }
         }
 


### PR DESCRIPTION
 - Fixed message signing. Adjusted parameters of `signMessage()`. Theoretically, this is a breaking change (adjustment of the public API) - practically, it's not, since it wasn't working previously.
 - Renamed error classes: theoretically, this is a breaking change. Practically, it's a non-breaking change - errors were meant to be internal.
- Removed interface `IMessage`. Theoretically, a breaking change. Practically, not, since the interface couldn't have been used with success to sign a message. Added a new one (to be consistent with other providers): `ISignableMessage`.

Signing a message:

```
// Using sdk-core's SignableMessage
provider.signMessage(new SignableMessage({ message: Buffer.from("hello") }))

// Using a simple buffer
provider.signMessage({ message: Buffer.from("hello") })
```

Retrieving the message signature (as a plain string): `provider.getMessageSignatureFromWalletUrl()`.