### PR TITLE
Make data field optional

### DIFF
--- a/src/walletProvider.spec.ts
+++ b/src/walletProvider.spec.ts
@@ -157,3 +157,46 @@ describe("test getTransactionsFromWalletUrl", () => {
     );
   });
 });
+
+describe("test getTransactionsFromWalletUrl with mandatory fields only", () => {
+
+
+  it("gets transactions from wallet url with mandatory fields only", async () => {
+    window.location.search = 
+          "?signSession=1693313444978" +
+          "&nonce[0]=127" +
+          "&value[0]=100000000000000000" +
+          "&receiver[0]=erd1qqqqqqqqqqqqqpgq7ykazrzd905zvnlr88dpfw06677lxe9w0n4suz00uh" +
+          "&sender[0]=erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th" +
+          "&gasPrice[0]=1000000000" +
+          "&gasLimit[0]=4200000" +
+          // data missing
+          "&chainID[0]=D" +
+          "&version[0]=1" +
+          "&signature[0]=414dcd2541ecdc1a41cafdd1ef4aff2ba7248402854478ee13c5a21968bd8dd4ab884335ea35c1404f85b0305f11df21615fecc9062e4668e74e8bb6a1e96c0d&walletProviderStatus=transactionsSigned";
+        
+    const walletProvider = new WalletProvider("http://mocked-wallet.com");
+    const signedTransactions = walletProvider.getTransactionsFromWalletUrl();
+
+    assert.equal(
+      JSON.stringify(signedTransactions),
+      JSON.stringify([
+        {
+          nonce: 127,
+          value: "100000000000000000",
+          receiver:
+            "erd1qqqqqqqqqqqqqpgq7ykazrzd905zvnlr88dpfw06677lxe9w0n4suz00uh",
+          sender:
+            "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th",
+          gasPrice: 1000000000,
+          gasLimit: 4200000,
+          data: "",
+          chainID: "D",
+          version: 1,
+          signature:
+            "414dcd2541ecdc1a41cafdd1ef4aff2ba7248402854478ee13c5a21968bd8dd4ab884335ea35c1404f85b0305f11df21615fecc9062e4668e74e8bb6a1e96c0d",
+        },
+      ])
+    );
+  });
+});

--- a/src/walletProvider.ts
+++ b/src/walletProvider.ts
@@ -175,37 +175,27 @@ export class WalletProvider {
 
 
         for (let i = 0; i < expectedLength; i++) {
-            
-            const transactionFields: Partial<PlainSignedTransaction> = {
-              nonce: parseInt(urlParams["nonce"][i]),
-              value: urlParams["value"][i],
-              receiver: urlParams["receiver"][i],
-              sender: urlParams["sender"][i],
-              gasPrice: parseInt(urlParams["gasPrice"][i]),
-              gasLimit: parseInt(urlParams["gasLimit"][i]),
-              signature: urlParams["signature"][i],
-              chainID: urlParams["chainID"][i],
-              version: parseInt(urlParams["version"][i])
-            };
-
-            const optionalFields: (keyof PlainSignedTransaction)[] = [
-              "data", 
-              "guardian",
-              "guardianSignature",
-              "senderUsername",
-              "receiverUsername",
-              "options"
-            ];
-
-            optionalFields.forEach(prop => {
-              const integerOptions = ["options"];
-              const hasProp = prop in urlParams && urlParams[prop][i];
-              if (hasProp) {
-                transactionFields[prop] = integerOptions.includes(prop) ? parseInt(urlParams[prop][i]) : urlParams[prop][i];
-              }
-            })
-
-            let plainSignedTransaction = new PlainSignedTransaction(transactionFields);
+            let plainSignedTransaction = new PlainSignedTransaction({
+                nonce: parseInt(urlParams["nonce"][i]),
+                value: urlParams["value"][i],
+                receiver: urlParams["receiver"][i],
+                sender: urlParams["sender"][i],
+                gasPrice: parseInt(urlParams["gasPrice"][i]),
+                gasLimit: parseInt(urlParams["gasLimit"][i]),
+                // Handle the optional "data" property.
+                data: urlParams["data"] && urlParams["data"][i] ? urlParams["data"][i] : "",
+                chainID: urlParams["chainID"][i],
+                version: parseInt(urlParams["version"][i]),
+                ...(urlParams["guardian"] && urlParams["guardian"][i] ? {guardian: urlParams["guardian"][i]} : {}),
+                ...(urlParams["guardianSignature"] && urlParams["guardianSignature"][i] ? {guardianSignature: urlParams["guardianSignature"][i]} : {}),
+                // Handle the optional "options" property.
+                ...(urlParams["options"] && urlParams["options"][i] ? {
+                    options: parseInt(urlParams["options"][i])
+                } : {}),
+                ...(urlParams["senderUsername"] && urlParams["senderUsername"][i] ? {senderUsername: urlParams["senderUsername"][i]} : {}),
+                ...(urlParams["receiverUsername"] && urlParams["receiverUsername"][i] ? {receiverUsername: urlParams["receiverUsername"][i]} : {}),
+                signature: urlParams["signature"][i]
+            });
 
             transactions.push(plainSignedTransaction);
         }

--- a/src/walletProvider.ts
+++ b/src/walletProvider.ts
@@ -197,7 +197,6 @@ export class WalletProvider {
               "options"
             ];
 
-            // optional string props
             optionalFields.forEach(prop => {
               const integerOptions = ["options"];
               const hasProp = prop in urlParams && urlParams[prop][i];

--- a/src/walletProvider.ts
+++ b/src/walletProvider.ts
@@ -172,28 +172,41 @@ export class WalletProvider {
 
         const transactions: PlainSignedTransaction[] = [];
 
+
+
         for (let i = 0; i < expectedLength; i++) {
-            let plainSignedTransaction = new PlainSignedTransaction({
-                nonce: parseInt(urlParams["nonce"][i]),
-                value: urlParams["value"][i],
-                receiver: urlParams["receiver"][i],
-                sender: urlParams["sender"][i],
-                gasPrice: parseInt(urlParams["gasPrice"][i]),
-                gasLimit: parseInt(urlParams["gasLimit"][i]),
-                // Handle the optional "data" property.
-                data: urlParams["data"][i] ?? "",
-                chainID: urlParams["chainID"][i],
-                version: parseInt(urlParams["version"][i]),
-                ...(urlParams["guardian"] && urlParams["guardian"][i] ? {guardian: urlParams["guardian"][i]} : {}),
-                ...(urlParams["guardianSignature"] && urlParams["guardianSignature"][i] ? {guardianSignature: urlParams["guardianSignature"][i]} : {}),
-                // Handle the optional "options" property.
-                ...(urlParams["options"] && urlParams["options"][i] ? {
-                    options: parseInt(urlParams["options"][i])
-                } : {}),
-                ...(urlParams["senderUsername"] && urlParams["senderUsername"][i] ? {senderUsername: urlParams["senderUsername"][i]} : {}),
-                ...(urlParams["receiverUsername"] && urlParams["receiverUsername"][i] ? {receiverUsername: urlParams["receiverUsername"][i]} : {}),
-                signature: urlParams["signature"][i]
-            });
+            
+            const transactionFields: Partial<PlainSignedTransaction> = {
+              nonce: parseInt(urlParams["nonce"][i]),
+              value: urlParams["value"][i],
+              receiver: urlParams["receiver"][i],
+              sender: urlParams["sender"][i],
+              gasPrice: parseInt(urlParams["gasPrice"][i]),
+              gasLimit: parseInt(urlParams["gasLimit"][i]),
+              signature: urlParams["signature"][i],
+              chainID: urlParams["chainID"][i],
+              version: parseInt(urlParams["version"][i])
+            };
+
+            const optionalFields: (keyof PlainSignedTransaction)[] = [
+              "data", 
+              "guardian",
+              "guardianSignature",
+              "senderUsername",
+              "receiverUsername",
+              "options"
+            ];
+
+            // optional string props
+            optionalFields.forEach(prop => {
+              const integerOptions = ["options"];
+              const hasProp = prop in urlParams && urlParams[prop][i];
+              if (hasProp) {
+                transactionFields[prop] = integerOptions.includes(prop) ? parseInt(urlParams[prop][i]) : urlParams[prop][i];
+              }
+            })
+
+            let plainSignedTransaction = new PlainSignedTransaction(transactionFields);
 
             transactions.push(plainSignedTransaction);
         }


### PR DESCRIPTION
This is a valid link: http://localhost:3000/dashboard?signSession=1699434437543&nonce[0]=254&value[0]=0&receiver[0]=erd1wh9c0sjr2xn8hzf02lwwcr4jk2s84tat9ud2kaq6zr7xzpvl9l5q8awmex&sender[0]=erd1wh9c0sjr2xn8hzf02lwwcr4jk2s84tat9ud2kaq6zr7xzpvl9l5q8awmex&gasPrice[0]=1000000000&gasLimit[0]=50000&chainID[0]=D&version[0]=1&signature[0]=e1c35288992ad30b998ecfd82d8beeaf91c598fe42896f8d3aa4aa31cad3f3ee1c9cc1533ba60c88a0a2c132cb04da02dd50f6b246e471f3bd25271cab9c6d05&walletProviderStatus=transactionsSigned

but has no data field in it

The current implementation
`                data: urlParams["data"][i] ?? "",
`
does throws an error because it cannot read from index `i`.

Proposed solution makes data field presence optional


